### PR TITLE
Fix Obsidian deep links and DeepLore drawer icon

### DIFF
--- a/src/drawer/drawer-events.js
+++ b/src/drawer/drawer-events.js
@@ -16,7 +16,7 @@ import {
     suppressNextAgenticLoop, setSuppressNextAgenticLoop,
 } from '../state.js';
 import { DEFAULT_FIELD_DEFINITIONS } from '../fields.js';
-import { normalizePinBlock, buildObsidianURI } from '../helpers.js';
+import { normalizePinBlock, buildObsidianURI, buildObsidianAnchorHtml, openExternalProtocol } from '../helpers.js';
 import { buildIndex } from '../vault/vault.js';
 import { openRuleBuilder } from '../ui/rule-builder.js';
 import {
@@ -380,6 +380,16 @@ export function wireBrowseTab($drawer) {
         });
     });
 
+    $drawer.on('click keydown', '.dle-obsidian-link', function (e) {
+        if (e.type === 'keydown' && e.key !== 'Enter' && e.key !== ' ') return;
+        e.preventDefault();
+        e.stopPropagation();
+        const uri = this.dataset?.obsidianUri;
+        if (!openExternalProtocol(uri)) {
+            toastr.warning('Could not open Obsidian link from this browser context.', 'DeepLore Enhanced', { timeOut: 2500 });
+        }
+    });
+
     $drawer.find('.dle-browse-input').on('input', function () {
         const val = $(this).val();
         clearTimeout(ds.browseSearchTimeout);
@@ -588,7 +598,7 @@ export function wireBrowseTab($drawer) {
             ? settings.vaults.find(v => v.name === entry.vaultSource) : null;
         const vaultName = srcVault ? srcVault.name : (settings.vaults?.[0]?.name || '');
         const uri = entry.filename ? buildObsidianURI(vaultName, entry.filename) : null;
-        const linkHtml = uri ? ` <a href="${escapeHtml(uri)}" class="dle-obsidian-link" aria-label="Open in Obsidian">Open in Obsidian</a>` : '';
+        const linkHtml = uri ? ` ${buildObsidianAnchorHtml(uri)}` : '';
 
         let fieldsHtml = '';
         if (entry.customFields && Object.keys(entry.customFields).length > 0) {

--- a/src/drawer/drawer-render-tabs.js
+++ b/src/drawer/drawer-render-tabs.js
@@ -8,7 +8,7 @@ import {
     fieldDefinitions,
 } from '../state.js';
 import { DEFAULT_FIELD_DEFINITIONS } from '../fields.js';
-import { buildObsidianURI, computeSourcesDiff, categorizeRejections, resolveEntryVault, normalizePinBlock } from '../helpers.js';
+import { buildObsidianURI, buildObsidianAnchorHtml, computeSourcesDiff, categorizeRejections, resolveEntryVault, normalizePinBlock } from '../helpers.js';
 import {
     ds, BROWSE_ROW_HEIGHT, BROWSE_OVERSCAN,
     getMatchLabel, computeEntryTemperatures,
@@ -121,7 +121,7 @@ export function renderInjectionTab() {
             h += `<div class="${classes.join(' ')}" style="--i:${idx}" role="listitem" aria-label="${entryAriaLabel}" data-title="${escapeHtml(src.title)}" data-count-key="${escapeHtml(countKey)}">`;
             h += `<span class="dle-why-title">`;
             if (uri) {
-                h += `<a href="${escapeHtml(uri)}" class="dle-obsidian-link" aria-label="Open in Obsidian">${escapeHtml(src.title)}</a>`;
+                h += buildObsidianAnchorHtml(uri, { text: src.title, ariaLabel: `Open ${src.title} in Obsidian` });
             } else {
                 h += escapeHtml(src.title);
             }
@@ -713,7 +713,7 @@ export function renderBrowseWindow() {
                     const srcVault = entry.vaultSource && settings.vaults ? settings.vaults.find(v => v.name === entry.vaultSource) : null;
                     const vaultName = srcVault ? srcVault.name : (settings.vaults?.[0]?.name || '');
                     const uri = entry.filename ? buildObsidianURI(vaultName, entry.filename) : null;
-                    const linkHtml = uri ? ` <a href="${escapeHtml(uri)}" class="dle-obsidian-link" aria-label="Open in Obsidian">Open in Obsidian</a>` : '';
+                    const linkHtml = uri ? ` ${buildObsidianAnchorHtml(uri)}` : '';
                     let fieldsHtml = '';
                     if (entry.customFields && Object.keys(entry.customFields).length > 0) {
                         const pairs = Object.entries(entry.customFields)

--- a/src/graph/graph-events.js
+++ b/src/graph/graph-events.js
@@ -1,5 +1,5 @@
 import { getVaultByName } from '../../settings.js';
-import { buildObsidianURI } from '../helpers.js';
+import { buildObsidianURI, openExternalProtocol } from '../helpers.js';
 import { computeGapAnalysis } from './graph-analysis.js';
 
 const escapeHtml = s => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
@@ -122,10 +122,7 @@ export function initEvents(gs, dbg) {
                 const uri = vault ? buildObsidianURI(vault.name, entry.filename) : null;
                 dbg(`Open in Obsidian: vault=${vault?.name || 'NONE'}, uri=${uri || 'NULL'}`);
                 if (uri) {
-                    // Anchor.click() works for custom protocols; some browsers block window.open() with non-http schemes.
-                    const a = document.createElement('a');
-                    a.href = uri;
-                    a.click();
+                    openExternalProtocol(uri);
                 } else {
                     dbg('WARNING: No vault found for entry, cannot build Obsidian URI');
                 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -219,6 +219,69 @@ export function buildObsidianURI(vaultName, filename) {
     return `obsidian://open?vault=${encodedVault}&file=${encodedFile}`;
 }
 
+function escapeHtmlValue(value) {
+    return String(value ?? '').replace(/[&<>"']/g, ch => ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+    }[ch]));
+}
+
+export function buildObsidianAnchorHtml(uri, {
+    text = 'Open in Obsidian',
+    className = 'dle-obsidian-link',
+    ariaLabel = 'Open in Obsidian',
+} = {}) {
+    if (!uri) return '';
+    return `<a href="#" data-obsidian-uri="${escapeHtmlValue(uri)}" class="${escapeHtmlValue(className)}" aria-label="${escapeHtmlValue(ariaLabel)}">${escapeHtmlValue(text)}</a>`;
+}
+
+/**
+ * Launch an external protocol without navigating the current SillyTavern tab.
+ * Must be called from a user activation handler (click/keyboard) for browsers
+ * that gate custom protocol launches.
+ * @param {string} uri
+ * @param {{documentRef?: Document, setTimeoutFn?: Function, cleanupDelayMs?: number}} opts
+ * @returns {boolean} true when a launch attempt was made
+ */
+export function openExternalProtocol(uri, {
+    documentRef = globalThis.document,
+    setTimeoutFn = globalThis.setTimeout,
+    cleanupDelayMs = 1000,
+} = {}) {
+    const rawUri = String(uri || '');
+    if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(rawUri)) return false;
+    if (!documentRef?.createElement || !documentRef.body?.appendChild) return false;
+
+    const iframe = documentRef.createElement('iframe');
+    iframe.setAttribute('aria-hidden', 'true');
+    iframe.tabIndex = -1;
+    Object.assign(iframe.style, {
+        position: 'absolute',
+        width: '0',
+        height: '0',
+        border: '0',
+        opacity: '0',
+        pointerEvents: 'none',
+    });
+
+    documentRef.body.appendChild(iframe);
+    iframe.src = rawUri;
+
+    const cleanup = () => {
+        try {
+            if (typeof iframe.remove === 'function') iframe.remove();
+            else if (iframe.parentNode?.removeChild) iframe.parentNode.removeChild(iframe);
+        } catch { /* noop */ }
+    };
+
+    if (typeof setTimeoutFn === 'function') setTimeoutFn(cleanup, cleanupDelayMs);
+    else cleanup();
+    return true;
+}
+
 /**
  * Convert a SillyTavern World Info entry into an Obsidian note with frontmatter.
  * @param {object} wiEntry

--- a/src/ui/popups.js
+++ b/src/ui/popups.js
@@ -18,7 +18,7 @@ import {
 } from '../state.js';
 import { buildIndex } from '../vault/vault.js';
 import { callAutoSuggest } from '../ai/auto-suggest.js';
-import { extractAiResponseClient, buildObsidianURI, STAGE_COLORS, normalizePinBlock } from '../helpers.js';
+import { extractAiResponseClient, buildObsidianURI, buildObsidianAnchorHtml, openExternalProtocol, STAGE_COLORS, normalizePinBlock } from '../helpers.js';
 import { diagnoseEntry } from './diagnostics.js';
 import { computeEntryTemperatures } from '../drawer/drawer-state.js';
 
@@ -314,7 +314,7 @@ export async function showBrowsePopup() {
                 : (settings.vaults?.[0]?.name || '');
             const obsidianUri = buildObsidianURI(entryVaultName, entry.filename);
             const obsidianLink = obsidianUri
-                ? ` <a href="${escapeHtml(obsidianUri)}" class="dle-text-xs dle-muted">Open in Obsidian</a>`
+                ? ` ${buildObsidianAnchorHtml(obsidianUri, { className: 'dle-text-xs dle-muted' })}`
                 : '';
 
             const temp = tempMap.get(trackerKey(entry));
@@ -374,6 +374,16 @@ export async function showBrowsePopup() {
     }
 
     // Delegation registered once on container — not per render.
+    container.addEventListener('click', (e) => {
+        const link = e.target.closest('.dle-obsidian-link');
+        if (!link) return;
+        e.preventDefault();
+        e.stopPropagation();
+        if (!openExternalProtocol(link.dataset?.obsidianUri)) {
+            toastr.warning('Could not open Obsidian link from this browser context.', 'DeepLore Enhanced', { timeOut: 2500 });
+        }
+    });
+
     container.addEventListener('click', (e) => {
         // Skip the row-toggle when the click landed in the inline action group.
         if (e.target.closest('[data-no-toggle="1"]')) return;

--- a/test/regression.test.mjs
+++ b/test/regression.test.mjs
@@ -45,7 +45,7 @@ import { validateCachedEntry } from '../src/vault/cache-validate.js';
 import { simpleHash, validateSettings, parseFrontmatter, buildScanText } from '../core/utils.js';
 import { testEntryMatch, formatAndGroup, applyGating, clearScanTextCache } from '../core/matching.js';
 import { parseVaultFile } from '../core/pipeline.js';
-import { normalizePinBlock, matchesPinBlock, cmrsResultToText } from '../src/helpers.js';
+import { normalizePinBlock, matchesPinBlock, cmrsResultToText, buildObsidianAnchorHtml, openExternalProtocol } from '../src/helpers.js';
 
 console.log('DeepLore Enhanced — Regression Tests');
 console.log('Each test guards a specific BUG fix or gotcha.\n');
@@ -1617,7 +1617,88 @@ test('Issue #24: usage falls back through OpenAI/Anthropic field names', () => {
     assertEqual(c.usage.output_tokens, 0);
 });
 
+// Obsidian deep-link safety
 // ============================================================================
+
+section('Obsidian deep-link safety');
+
+test('Obsidian links open outside the SillyTavern tab', () => {
+    const link = buildObsidianAnchorHtml('obsidian://open?vault=First%20Vault&file=Cosplay%20Mode');
+
+    assert(link.includes('href="#"'), 'obsidian:// link should not navigate the ST tab directly');
+    assert(link.includes('data-obsidian-uri="obsidian://open?vault=First%20Vault&amp;file=Cosplay%20Mode"'), 'uri should be stored for the click launcher');
+    assert(!link.includes('target="_blank"'), 'obsidian:// link should not leave a visible browser tab behind');
+});
+
+test('Obsidian links escape labels and attributes', () => {
+    const link = buildObsidianAnchorHtml('obsidian://open?vault=A&B&file=<bad>', {
+        text: 'Open <Mode>',
+        className: 'dle-obsidian-link custom',
+        ariaLabel: 'Open "Mode"',
+    });
+
+    assert(link.includes('Open &lt;Mode&gt;'), 'link text should be escaped');
+    assert(link.includes('class="dle-obsidian-link custom"'), 'class name should be preserved');
+    assert(link.includes('aria-label="Open &quot;Mode&quot;"'), 'aria label should be escaped');
+    assert(link.includes('data-obsidian-uri="obsidian://open?vault=A&amp;B&amp;file=&lt;bad&gt;"'), 'uri data attribute should be escaped');
+});
+
+test('External protocol launcher uses a hidden iframe and cleans it up', () => {
+    const appended = [];
+    let cleanup = null;
+    let cleanupDelay = 0;
+    const fakeBody = {
+        appendChild(node) {
+            appended.push(node);
+            node.parentNode = this;
+        },
+        removeChild(node) {
+            node.removedByParent = true;
+        },
+    };
+    const fakeDocument = {
+        body: fakeBody,
+        createElement(tag) {
+            return {
+                tagName: tag.toUpperCase(),
+                style: {},
+                attributes: {},
+                setAttribute(name, value) { this.attributes[name] = value; },
+                remove() { this.removed = true; },
+            };
+        },
+    };
+
+    const uri = 'obsidian://open?vault=First%20Vault&file=Cosplay%20Mode';
+    const opened = openExternalProtocol(uri, {
+        documentRef: fakeDocument,
+        setTimeoutFn(fn, delay) {
+            cleanup = fn;
+            cleanupDelay = delay;
+        },
+    });
+
+    assert(opened, 'valid external protocol should be launched');
+    assertEqual(appended.length, 1, 'one iframe should be appended');
+    assertEqual(appended[0].tagName, 'IFRAME', 'launcher should use an iframe');
+    assertEqual(appended[0].src, uri, 'iframe should receive the external protocol URI');
+    assertEqual(appended[0].attributes['aria-hidden'], 'true', 'iframe should be hidden from assistive tech');
+    assertEqual(cleanupDelay, 1000, 'iframe cleanup should be delayed briefly');
+    cleanup();
+    assert(appended[0].removed, 'iframe should be removed after launch');
+});
+
+test('External protocol launcher rejects non-protocol or missing document inputs', () => {
+    const fakeDocument = {
+        body: { appendChild() { throw new Error('should not append'); } },
+        createElement() { throw new Error('should not create'); },
+    };
+
+    assert(!openExternalProtocol('', { documentRef: fakeDocument }), 'empty uri should not launch');
+    assert(!openExternalProtocol('/relative/path', { documentRef: fakeDocument }), 'relative uri should not launch');
+    assert(!openExternalProtocol('obsidian://open?vault=A', { documentRef: null }), 'missing document should not launch');
+});
+
 // Summary
 // ============================================================================
 


### PR DESCRIPTION
Edit:
## Summary
- Fixes Obsidian deep links so clicking `Open in Obsidian` no longer navigates the SillyTavern browser tab away from the UI.
- Launches `obsidian://` URIs through a hidden iframe instead of direct anchor navigation.
- Applies the same handling across drawer browse links, browse popup links, and graph entry links.
- Adds regression coverage for Obsidian link rendering, escaping, iframe launch behavior, and invalid URI handling.

## Notes
This is scoped to the long-standing direct `obsidian://` anchor issue. The earlier drawer-icon guard was intentionally left out after testing showed the Obsidian navigation was the confirmed repro path.

## Test plan
- [x] `npm run test:regression`
- [x] `npm run test:imports`
- [x] `npm run test:all`

:robot: found the issue by the help of codex, made pr with the help of claude.