### PR TITLE
fix(librarian): correct stale advanced-toggle CSS classes

### DIFF
--- a/settings-popup.html
+++ b/settings-popup.html
@@ -1174,10 +1174,10 @@
 
                 <!-- Advanced (collapsible) -->
                 <div class="dle-advanced-toggle" data-section="sp_librarian_advanced" tabindex="0" role="button" aria-expanded="false">
-                    <i class="fa-solid fa-chevron-right fa-xs dle-advanced-chevron" aria-hidden="true"></i>
+                    <i class="fa-solid fa-chevron-right fa-xs dle-advanced-icon" aria-hidden="true"></i>
                     <span data-i18n="dle_librarian_show_advanced_toggle">Show Advanced</span>
                 </div>
-                <div class="dle-advanced-content" data-section="sp_librarian_advanced" style="display: none;">
+                <div class="dle-advanced-section" data-section="sp_librarian_advanced" style="display: none;">
                     <div class="flex-container">
                         <div class="flex1" title="Maximum characters of the vault manifest section of the Librarian session prompt. As a rough guide, 8,000 characters is about 2,300 tokens. Default: 8000." data-i18n="[title]dle_librarian_manifest_max_tooltip">
                             <label for="dle-sp-librarian-manifest-max"><small data-i18n="dle_librarian_manifest_max_label">Manifest Budget (characters)</small></label>


### PR DESCRIPTION
## Summary

The Librarian settings' "Show Advanced" toggle in `settings-popup.html` used `dle-advanced-chevron` and `dle-advanced-content` classes, which have no matching rules in `style.css`. Every other "Show Advanced" toggle in the same file (Vault Tags, Matching, Injection, AI Prompt & Context, AI Filtering, AI Search, Index — 7 total) correctly uses `dle-advanced-icon` / `dle-advanced-section`, which are styled at `style.css:282` and `style.css:849`.

As a result, only the Librarian Advanced toggle rendered without the chevron rotation/spacing styling that every other Advanced section gets.

## Root cause

Likely a naming-convention drift — the Librarian section's markup used an earlier/local class-naming scheme (`-chevron` / `-content`) that was never reconciled with the convention (`-icon` / `-section`) used elsewhere.

## Fix

Renamed the two classes to match the established convention (2-line diff in `settings-popup.html`).

## Test plan

- [x] `npm run test:all` — 6866 passed, 0 failed
- [x] `npm run lint` — 0 errors (pre-existing warnings unrelated to this file)
- [x] Manually verified in a running SillyTavern instance